### PR TITLE
Allow use of SSM & KMS DW-5178

### DIFF
--- a/ci/vars.yml
+++ b/ci/vars.yml
@@ -1,1 +1,1 @@
-ucfs_claimant_kafka_consumer_version: "@sha256:35456427f546d472d35c636561222b50d4974fd213564006a0e187c53a946a33"
+ucfs_claimant_kafka_consumer_version: "@sha256:d983789f0ae9616847a140b71cb0da08a8ddc37beac000d31fc3e5ce43e2b011"

--- a/ecs.tf
+++ b/ecs.tf
@@ -63,6 +63,14 @@ resource "aws_ecs_task_definition" "claimant_api_kafka_consumer" {
     ],
     "environment": [
       {
+        "name": "AWS_CMK_ALIAS",
+        "value": "${data.terraform_remote_state.ucfs_claimant.outputs.ucfs_claimant_api_etl_cmk.name}"
+      },
+      {
+        "name": "AWS_SALT_PARAMETER_NAME",
+        "value": "${data.terraform_remote_state.ucfs_claimant.outputs.nino_salt_london_ssm_param}"
+      },
+      {
         "name": "CONTAINER_VERSION",
         "value": "${var.ucfs_claimant_kafka_consumer_version}"
       },

--- a/iam.tf
+++ b/iam.tf
@@ -2,6 +2,10 @@ locals {
   iam_name = replace(title(var.friendly_name), "-", "")
 }
 
+data "aws_ssm_parameter" "nino_salt_london_ssm_param" {
+  name = data.terraform_remote_state.ucfs_claimant.outputs.nino_salt_london_ssm_param
+}
+
 resource "aws_iam_role" "claimant_api_kafka_consumer" {
   name               = local.iam_name
   assume_role_policy = data.terraform_remote_state.common.outputs.ecs_assume_role_policy_json
@@ -15,6 +19,7 @@ resource "aws_iam_role" "claimant_api_kafka_consumer" {
 }
 
 resource "aws_iam_role_policy" "claimant_api_kafka_consumer" {
+  name   = "claimant_api_kafka_consumer"
   policy = data.aws_iam_policy_document.claimant_api_kafka_consumer.json
   role   = aws_iam_role.claimant_api_kafka_consumer.id
 }
@@ -51,5 +56,31 @@ data "aws_iam_policy_document" "claimant_api_kafka_consumer" {
       "logs:DescribeLogStreams"
     ]
     resources = [aws_cloudwatch_log_group.claimant_api_kafka_consumer.arn]
+  }
+
+  statement {
+    sid       = "AllowSSMGetNinoSalt"
+    effect    = "Allow"
+    actions   = ["ssm:GetParameter"]
+    resources = [data.aws_ssm_parameter.nino_salt_london_ssm_param.arn, ]
+  }
+
+  statement {
+    sid     = "AllowKMSDecryptNinoSalt"
+    effect  = "Allow"
+    actions = ["kms:Decrypt", ]
+
+    resources = [data.terraform_remote_state.ucfs_claimant.outputs.ucfs_nino_salt_cmk_london.arn, ]
+  }
+
+  statement {
+    sid    = "AllowKMSEncrypt"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:Encrypt",
+    ]
+
+    resources = [data.terraform_remote_state.ucfs_claimant.outputs.ucfs_claimant_api_etl_cmk.arn, ]
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -33,8 +33,6 @@ locals {
   stub_kafka_broker_port_https = data.terraform_remote_state.ingestion.outputs.locals.stub_kafka_broker_port_https
 
   kafka_data_source_is_ucfs = data.terraform_remote_state.ingestion.outputs.locals.k2hb_data_source_is_ucfs
-  peer_with_ucfs            = data.terraform_remote_state.ingestion.outputs.locals.peer_with_ucfs
-  peer_with_ucfs_london     = data.terraform_remote_state.ingestion.outputs.locals.peer_with_ucfs_london
 
   ucfs_ha_broker_prefix               = data.terraform_remote_state.ingestion.outputs.locals.ucfs_ha_broker_prefix
   ucfs_london_domains                 = data.terraform_remote_state.ingestion.outputs.locals.ucfs_london_domains

--- a/terraform.tf.j2
+++ b/terraform.tf.j2
@@ -140,3 +140,17 @@ data "terraform_remote_state" "dataworks_aws_ingestion_ecs_cluster" {
     dynamodb_table = "remote_state_locks"
   }
 }
+
+data "terraform_remote_state" "ucfs_claimant" {
+  backend   = "s3"
+  workspace = terraform.workspace
+
+  config = {
+    bucket         = "{{terraform.state_file_bucket}}"
+    key            = "terraform/dataworks/ucfs-claimant.tfstate"
+    region         = "{{terraform.state_file_region}}"
+    encrypt        = true
+    kms_key_id     = "arn:aws:kms:{{terraform.state_file_region}}:{{terraform.state_file_account}}:key/{{terraform.state_file_kms_key}}"
+    dynamodb_table = "remote_state_locks"
+  }
+}


### PR DESCRIPTION
* Claimant API Kafka consumers have access to retrieve the NINO salt from a parameter in Systems Manager (SSM)
* Claimant API Kafka consumers can encrypt data with KMS
* Some unused locals are removed 