### PR TITLE
Monitoring additions for Claimant API

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -153,7 +153,7 @@ resource "aws_ecs_service" "claimant_api_kafka_consumer" {
   name            = var.friendly_name
   cluster         = data.terraform_remote_state.dataworks_aws_ingestion_ecs_cluster.outputs.ingestion_ecs_cluster.id
   task_definition = aws_ecs_task_definition.claimant_api_kafka_consumer.arn
-  desired_count   = 0
+  desired_count   = local.task_count[local.environment]
   launch_type     = "EC2"
 
   network_configuration {

--- a/locals.tf
+++ b/locals.tf
@@ -152,10 +152,10 @@ locals {
 
   monitoring_topic_arn = data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn
 
-  claimant_api_consumer_metrics_namespace             = "/app/claimant-api-kafka-consumer"
+  claimant_api_consumer_metrics_namespace = "/app/claimant-api-kafka-consumer"
 
-  claimant_api_consumer_processed_batch = "The number of batches successfully processed into the Claimant RDS"
-  claimant_api_consumer_failed_batches  = "The number of batches which have failed to be processed into the Claimant RDS"
+  claimant_api_consumer_processed_batch                 = "The number of batches successfully processed into the Claimant RDS"
+  claimant_api_consumer_failed_batches                  = "The number of batches which have failed to be processed into the Claimant RDS"
   claimant_api_consumer_running_tasks_less_than_desired = "Claimant API Kafka Consumer - Running tasks less than desired for more than 5 minutes"
 
   claimant_api_consumer_alert_on_lack_of_processed_batches = {
@@ -174,7 +174,7 @@ locals {
     production    = true
   }
 
-  claimant_api_consumer_running_tasks_less_than_desired = {
+  claimant_api_consumer_alert_on_running_tasks_less_than_desired = {
     development   = true
     qa            = true
     integraton    = true

--- a/locals.tf
+++ b/locals.tf
@@ -149,4 +149,27 @@ locals {
     preprod     = "^(db[.])core[.](claimant|contract|statement)$"
     production  = "^(db[.])core[.](claimant|contract|statement)$"
   }
+
+  monitoring_topic_arn = data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn
+
+  claimant_api_consumer_metrics_namespace             = "/app/claimant-api-kafka-consumer"
+
+  claimant_api_consumer_processed_batch = "The number of batches successfully processed into the Claimant RDS"
+  claimant_api_consumer_failed_batches = "The number of batches which have failed to be processed into the Claimant RDS"
+
+  claimant_api_consumer_alert_on_lack_of_processed_batches = {
+    development   = false
+    qa            = false
+    integraton    = false
+    preproduction = false
+    production    = true
+  }
+
+  claimant_api_consumer_alert_on_failed_batches = {
+    development   = false
+    qa            = false
+    integraton    = false
+    preproduction = false
+    production    = true
+  }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -12,6 +12,14 @@ locals {
     production  = "management"
   }
 
+  task_count = {
+    development = 3
+    qa          = 3
+    integration = 3
+    preprod     = 3
+    production  = 3
+  }
+
   certificate_auth_public_cert_bucket = data.terraform_remote_state.certificate_authority.outputs.public_cert_bucket
   k2hb_data_source_is_ucfs            = data.terraform_remote_state.ingestion.outputs.locals.k2hb_data_source_is_ucfs
 

--- a/locals.tf
+++ b/locals.tf
@@ -155,7 +155,8 @@ locals {
   claimant_api_consumer_metrics_namespace             = "/app/claimant-api-kafka-consumer"
 
   claimant_api_consumer_processed_batch = "The number of batches successfully processed into the Claimant RDS"
-  claimant_api_consumer_failed_batches = "The number of batches which have failed to be processed into the Claimant RDS"
+  claimant_api_consumer_failed_batches  = "The number of batches which have failed to be processed into the Claimant RDS"
+  claimant_api_consumer_running_tasks_less_than_desired = "Claimant API Kafka Consumer - Running tasks less than desired for more than 5 minutes"
 
   claimant_api_consumer_alert_on_lack_of_processed_batches = {
     development   = false
@@ -170,6 +171,14 @@ locals {
     qa            = false
     integraton    = false
     preproduction = false
+    production    = true
+  }
+
+  claimant_api_consumer_running_tasks_less_than_desired = {
+    development   = true
+    qa            = true
+    integraton    = true
+    preproduction = true
     production    = true
   }
 }

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -1,0 +1,73 @@
+resource "aws_cloudwatch_log_metric_filter" "successfully_processed_batch" {
+  log_group_name = aws_cloudwatch_log_group.claimant_api_kafka_consumer.name
+  name           = local.claimant_api_consumer_processed_batch
+  pattern        = "{$.message = \"Processed batch, committing offset\"}"
+
+  metric_transformation {
+    name      = local.claimant_api_consumer_processed_batch
+    namespace = local.claimant_api_consumer_metrics_namespace
+    value     = 1
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "successfully_processed_batch" {
+  count       = local.claimant_api_consumer_alert_on_lack_of_processed_batches[local.environment] ? 1 : 0
+  metric_name = aws_cloudwatch_log_metric_filter.successfully_processed_batch.name
+
+  namespace           = local.claimant_api_consumer_metrics_namespace
+  alarm_name          = "Claimant API Kafka Consumer - Lack of processed batches in the last 3 hours"
+  alarm_description   = "Managed by ${local.common_tags.Application} repository"
+  alarm_actions       = [local.monitoring_topic_arn]
+  evaluation_periods  = 3
+  period              = 3600
+  threshold           = 1
+  statistic           = "Sum"
+  comparison_operator = "LessThanThreshold"
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name              = "claimant-api-kafka-consumer-processed-batches",
+      notification_type = "Warning",
+      severity          = "High"
+    },
+  )
+}
+
+
+resource "aws_cloudwatch_log_metric_filter" "failed_processing_batch" {
+  log_group_name = aws_cloudwatch_log_group.claimant_api_kafka_consumer.name
+  name           = local.claimant_api_consumer_failed_batches
+  pattern        = "{$.message = \"Inserted record\" || $.message = \"Updated record\"}"
+
+  metric_transformation {
+    name      = local.claimant_api_consumer_failed_batches
+    namespace = local.claimant_api_consumer_metrics_namespace
+    value     = 1
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "failed_processing_batch" {
+  count       = local.claimant_api_consumer_alert_on_failed_batches[local.environment] ? 1 : 0
+  metric_name = aws_cloudwatch_log_metric_filter.failed_processing_batch.name
+
+  namespace           = local.claimant_api_consumer_metrics_namespace
+  alarm_name          = "Claimant API Kafka Consumer - Failed to process batch"
+  alarm_description   = "Managed by ${local.common_tags.Application} repository"
+  alarm_actions       = [local.monitoring_topic_arn]
+  evaluation_periods  = 1
+  period              = 300
+  threshold           = 1
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
+
+  tags = merge(
+  local.common_tags,
+  {
+    Name              = "claimant-api-kafka-consumer-failed-processing-batch",
+    notification_type = "Warning",
+    severity          = "High"
+  },
+  )
+}
+

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -71,3 +71,63 @@ resource "aws_cloudwatch_metric_alarm" "failed_processing_batch" {
   )
 }
 
+resource "aws_cloudwatch_metric_alarm" "running_tasks_less_than_desired" {
+  count               = local.claimant_api_consumer_running_tasks_less_than_desired[local.environment] ? 1 : 0
+  alarm_name          = local.claimant_api_consumer_running_tasks_less_than_desired
+  alarm_description   = "Managed by ${local.common_tags.Application} repository"
+  alarm_actions       = [local.monitoring_topic_arn]
+  treat_missing_data  = "breaching"
+  evaluation_periods  = 2
+  threshold           = 0
+  comparison_operator = "GreaterThanThreshold"
+
+  metric_query {
+    id          = "e1"
+    expression  = "IF(m1 < m2, 1, 0)"
+    label       = "DesiredCountNotMet"
+    return_data = "true"
+  }
+
+  metric_query {
+    id = "m1"
+
+    metric {
+      metric_name = "RunningTaskCount"
+      namespace   = "ECS/ContainerInsights"
+      period      = "60"
+      stat        = "Sum"
+      unit        = "Count"
+
+      dimensions = {
+        ServiceName = "claimant-api-kafka-consumer"
+        ClusterName = "ingestion"
+      }
+    }
+  }
+
+  metric_query {
+    id = "m2"
+
+    metric {
+      metric_name = "DesiredTaskCount"
+      namespace = "ECS/ContainerInsights"
+      period = "60"
+      stat = "Sum"
+      unit = "Count"
+
+      dimensions = {
+        ServiceName = "claimant-api-kafka-consumer"
+        ClusterName = "ingestion"
+      }
+    }
+  }
+
+  tags = merge(
+  local.common_tags,
+  {
+    Name              = "claimant-api-kafka-consumer-failed-processing-batch",
+    notification_type = "Warning",
+    severity          = "High"
+  },
+  )
+}

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -62,17 +62,17 @@ resource "aws_cloudwatch_metric_alarm" "failed_processing_batch" {
   comparison_operator = "GreaterThanThreshold"
 
   tags = merge(
-  local.common_tags,
-  {
-    Name              = "claimant-api-kafka-consumer-failed-processing-batch",
-    notification_type = "Warning",
-    severity          = "High"
-  },
+    local.common_tags,
+    {
+      Name              = "claimant-api-kafka-consumer-failed-processing-batch",
+      notification_type = "Warning",
+      severity          = "High"
+    },
   )
 }
 
 resource "aws_cloudwatch_metric_alarm" "running_tasks_less_than_desired" {
-  count               = local.claimant_api_consumer_running_tasks_less_than_desired[local.environment] ? 1 : 0
+  count               = local.claimant_api_consumer_alert_on_running_tasks_less_than_desired[local.environment] ? 1 : 0
   alarm_name          = local.claimant_api_consumer_running_tasks_less_than_desired
   alarm_description   = "Managed by ${local.common_tags.Application} repository"
   alarm_actions       = [local.monitoring_topic_arn]
@@ -110,10 +110,10 @@ resource "aws_cloudwatch_metric_alarm" "running_tasks_less_than_desired" {
 
     metric {
       metric_name = "DesiredTaskCount"
-      namespace = "ECS/ContainerInsights"
-      period = "60"
-      stat = "Sum"
-      unit = "Count"
+      namespace   = "ECS/ContainerInsights"
+      period      = "60"
+      stat        = "Sum"
+      unit        = "Count"
 
       dimensions = {
         ServiceName = "claimant-api-kafka-consumer"
@@ -123,11 +123,11 @@ resource "aws_cloudwatch_metric_alarm" "running_tasks_less_than_desired" {
   }
 
   tags = merge(
-  local.common_tags,
-  {
-    Name              = "claimant-api-kafka-consumer-failed-processing-batch",
-    notification_type = "Warning",
-    severity          = "High"
-  },
+    local.common_tags,
+    {
+      Name              = "claimant-api-kafka-consumer-failed-processing-batch",
+      notification_type = "Warning",
+      severity          = "High"
+    },
   )
 }

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_metric_alarm" "successfully_processed_batch" {
 resource "aws_cloudwatch_log_metric_filter" "failed_processing_batch" {
   log_group_name = aws_cloudwatch_log_group.claimant_api_kafka_consumer.name
   name           = local.claimant_api_consumer_failed_batches
-  pattern        = "{$.message = \"Inserted record\" || $.message = \"Updated record\"}"
+  pattern        = "{$.message = \"Batch failed, not committing offset, resetting position to last commit\"}"
 
   metric_transformation {
     name      = local.claimant_api_consumer_failed_batches
@@ -77,7 +77,7 @@ resource "aws_cloudwatch_metric_alarm" "running_tasks_less_than_desired" {
   alarm_description   = "Managed by ${local.common_tags.Application} repository"
   alarm_actions       = [local.monitoring_topic_arn]
   treat_missing_data  = "breaching"
-  evaluation_periods  = 2
+  evaluation_periods  = 5
   threshold           = 0
   comparison_operator = "GreaterThanThreshold"
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,6 +20,6 @@ output "claimant_api_kafka_consumer" {
 
 output "claimant_api_kafka_consumer_iam" {
   value = {
-    role   = aws_iam_role.claimant_api_kafka_consumer
+    role = aws_iam_role.claimant_api_kafka_consumer
   }
 }

--- a/terraform.tf.j2
+++ b/terraform.tf.j2
@@ -154,3 +154,17 @@ data "terraform_remote_state" "ucfs_claimant" {
     dynamodb_table = "remote_state_locks"
   }
 }
+
+data "terraform_remote_state" "security-tools" {
+  backend   = "s3"
+  workspace = terraform.workspace
+
+  config = {
+    bucket         = "{{terraform.state_file_bucket}}"
+    key            = "terraform/dataworks/aws-security-tools.tfstate"
+    region         = "{{terraform.state_file_region}}"
+    encrypt        = true
+    kms_key_id     = "arn:aws:kms:{{terraform.state_file_region}}:{{terraform.state_file_account}}:key/{{terraform.state_file_kms_key}}"
+    dynamodb_table = "remote_state_locks"
+  }
+}


### PR DESCRIPTION
Metric and alarm for lack of successful puts to Claimant RDS in 3 hours (lack of noise alarm)
Metric and alarm for failed to record batch to Claimant RDS
Alarm for when claimant-api-kafka-consumer tasks < desired count for longer than 2 minutes.