### PR TITLE
Consumer use ireland cmk

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -64,7 +64,7 @@ resource "aws_ecs_task_definition" "claimant_api_kafka_consumer" {
     "environment": [
       {
         "name": "AWS_CMK_ALIAS",
-        "value": "${local.claimant_api_consumer_use_ireland_kms ? data.terraform_remote_state.ucfs_claimant.outputs.ucfs_etl_cmk.arn : data.terraform_remote_state.ucfs_claimant.outputs.ucfs_claimant_api_etl_cmk.name}"
+        "value": "${local.claimant_api_consumer_use_ireland_kms[local.environment] ? data.terraform_remote_state.ucfs_claimant.outputs.ucfs_etl_cmk.arn : data.terraform_remote_state.ucfs_claimant.outputs.ucfs_claimant_api_etl_cmk.name}"
       },
       {
         "name": "AWS_SALT_PARAMETER_NAME",

--- a/ecs.tf
+++ b/ecs.tf
@@ -153,7 +153,7 @@ resource "aws_ecs_service" "claimant_api_kafka_consumer" {
   name            = var.friendly_name
   cluster         = data.terraform_remote_state.dataworks_aws_ingestion_ecs_cluster.outputs.ingestion_ecs_cluster.id
   task_definition = aws_ecs_task_definition.claimant_api_kafka_consumer.arn
-  desired_count   = 0
+  desired_count   = local.task_count[local.environment]
   launch_type     = "EC2"
 
   network_configuration {

--- a/ecs.tf
+++ b/ecs.tf
@@ -64,7 +64,7 @@ resource "aws_ecs_task_definition" "claimant_api_kafka_consumer" {
     "environment": [
       {
         "name": "AWS_CMK_ALIAS",
-        "value": "${data.terraform_remote_state.ucfs_claimant.outputs.ucfs_claimant_api_etl_cmk.name}"
+        "value": "${local.claimant_api_consumer_use_ireland_kms ? data.terraform_remote_state.ucfs_claimant.outputs.ucfs_etl_cmk.arn : data.terraform_remote_state.ucfs_claimant.outputs.ucfs_claimant_api_etl_cmk.name}"
       },
       {
         "name": "AWS_SALT_PARAMETER_NAME",

--- a/iam.tf
+++ b/iam.tf
@@ -82,7 +82,7 @@ data "aws_iam_policy_document" "claimant_api_kafka_consumer" {
       "kms:GenerateDataKey",
     ]
 
-    resources = [data.terraform_remote_state.ucfs_claimant.outputs.ucfs_claimant_api_etl_cmk.arn, ]
+    resources = [data.terraform_remote_state.ucfs_claimant.outputs.ucfs_claimant_api_etl_cmk.arn, data.terraform_remote_state.ucfs_claimant.outputs.ucfs_etl_cmk.arn]
   }
 
   statement {

--- a/locals.tf
+++ b/locals.tf
@@ -185,8 +185,8 @@ locals {
   claimant_api_consumer_use_ireland_kms = {
     development = true
     qa          = true
-    integration = false
-    preprod     = false
-    production  = false
+    integration = true
+    preprod     = true
+    production  = true
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -181,4 +181,12 @@ locals {
     preprod     = true
     production  = true
   }
+
+  claimant_api_consumer_use_ireland_kms = {
+    development = true
+    qa          = true
+    integration = true
+    preprod     = true
+    production  = true
+  }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -185,8 +185,8 @@ locals {
   claimant_api_consumer_use_ireland_kms = {
     development = true
     qa          = true
-    integration = true
-    preprod     = true
-    production  = true
+    integration = false
+    preprod     = false
+    production  = false
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -12,6 +12,14 @@ locals {
     production  = "management"
   }
 
+  task_count = {
+    development = 3
+    qa          = 3
+    integration = 3
+    preprod     = 3
+    production  = 3
+  }
+
   certificate_auth_public_cert_bucket = data.terraform_remote_state.certificate_authority.outputs.public_cert_bucket
   k2hb_data_source_is_ucfs            = data.terraform_remote_state.ingestion.outputs.locals.k2hb_data_source_is_ucfs
 


### PR DESCRIPTION
Change consumer to use Ireland CMK so that we can transition to using London data source but down stream users don't need to modify their key in order to decrypt data.